### PR TITLE
Set CMake Project Languages to None

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(
   VERSION 0.0.0
   DESCRIPTION "Fix source codes formatting in your CMake project "
   HOMEPAGE_URL https://github.com/threeal/FixFormat.cmake
+  LANGUAGES NONE
 )
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
This pull request simply sets the `LANGUAGES` property to `NONE` in the `project` function of `CMakeLists.txt`. This change is made to disable all languages in this project.