### PR TITLE
Add Support to Format Headers

### DIFF
--- a/cmake/FixFormat.cmake
+++ b/cmake/FixFormat.cmake
@@ -13,6 +13,17 @@ function(target_fix_format TARGET)
     endforeach()
   endif()
 
+  # Append header files of the target to be formatted.
+  foreach(PROP INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(TARGET_INCLUDE_DIRS ${TARGET} ${PROP})
+    if(NOT "${TARGET_INCLUDE_DIRS}" STREQUAL TARGET_INCLUDE_DIRS-NOTFOUND)
+      foreach(INCLUDE_DIR ${TARGET_INCLUDE_DIRS})
+        file(GLOB_RECURSE HEADERS CONFIGURE_DEPENDS "${INCLUDE_DIR}/*")
+        list(APPEND FILES ${HEADERS})
+      endforeach()
+    endif()
+  endforeach()
+
   if(FILES)
     # Set a lock file to prevent formatting from always running.
     get_target_property(TARGET_BINARY_DIR ${TARGET} BINARY_DIR)

--- a/test/FixFormatTest.cmake
+++ b/test/FixFormatTest.cmake
@@ -1,4 +1,10 @@
-set(SRCS src/fibonacci.cpp src/is_odd.cpp)
+set(
+  SRCS
+  include/fibonacci.hpp
+  include/is_odd.hpp
+  src/fibonacci.cpp
+  src/is_odd.cpp
+)
 
 message(STATUS "Getting the original source file hashes")
 foreach(SRC ${SRCS})

--- a/test/sample/dirty/include/fibonacci.hpp
+++ b/test/sample/dirty/include/fibonacci.hpp
@@ -1,0 +1,3 @@
+#include<vector>
+
+std::vector< int>    fibonacci_sequence(int   n) ;

--- a/test/sample/dirty/include/is_odd.hpp
+++ b/test/sample/dirty/include/is_odd.hpp
@@ -1,0 +1,1 @@
+bool    is_odd (  int val);


### PR DESCRIPTION
This pull request resolves #5 by adding support to format header files in the `target_fix_format` function'.