### PR TITLE
Bump Copyright Year to 2024

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Alfi Maulana
+Copyright (c) 2023-2024 Alfi Maulana
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ FixFormat.cmake is a [CMake](https://cmake.org/) module that provides utility fu
 
 This project is licensed under the terms of the [MIT License](./LICENSE).
 
-Copyright © 2023 [Alfi Maulana](https://github.com/threeal)
+Copyright © 2023-2024 [Alfi Maulana](https://github.com/threeal)


### PR DESCRIPTION
This pull request simply bumps the copyright year to 2024 both in the `README.md` file and the `LICENSE` file.