### PR TITLE
Disable Install on Subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,27 +17,29 @@ if(SUBPROJECT)
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} PARENT_SCOPE)
 endif()
 
-if(NOT SUBPROJECT AND BUILD_TESTING)
-  enable_testing()
+if(NOT SUBPROJECT)
+  if(BUILD_TESTING)
+    enable_testing()
 
-  list(APPEND ARGS -B ${CMAKE_CURRENT_BINARY_DIR} -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH})
+    list(APPEND ARGS -B ${CMAKE_CURRENT_BINARY_DIR} -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH})
 
-  add_test(
-    NAME "Testing source codes formatting"
-    COMMAND cmake ${ARGS} -P ${CMAKE_CURRENT_SOURCE_DIR}/test/FixFormatTest.cmake
+    add_test(
+      NAME "Testing source codes formatting"
+      COMMAND cmake ${ARGS} -P ${CMAKE_CURRENT_SOURCE_DIR}/test/FixFormatTest.cmake
+    )
+  endif()
+
+  include(CMakePackageConfigHelpers)
+  write_basic_package_version_file(
+    FixFormatConfigVersion.cmake
+    COMPATIBILITY SameMajorVersion
+  )
+
+  install(
+    FILES
+      cmake/FixFormat.cmake
+      cmake/FixFormatConfig.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/FixFormatConfigVersion.cmake
+    DESTINATION lib/cmake/FixFormat
   )
 endif()
-
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-  FixFormatConfigVersion.cmake
-  COMPATIBILITY SameMajorVersion
-)
-
-install(
-  FILES
-    cmake/FixFormat.cmake
-    cmake/FixFormatConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/FixFormatConfigVersion.cmake
-  DESTINATION lib/cmake/FixFormat
-)


### PR DESCRIPTION
This pull request resolves #14 by enabling the installation target only if the project is not included as a subproject. 