### PR TITLE
Add Include Guard in Sample Modules

### DIFF
--- a/cmake/FixFormat.cmake
+++ b/cmake/FixFormat.cmake
@@ -1,3 +1,5 @@
+include_guard(GLOBAL)
+
 # Function to format source files of a specific target.
 # Arguments:
 #   - TARGET: The target for which to format the source files.


### PR DESCRIPTION
This pull request resolves #16 by adding an `include_guard` function on the top of the `FixFormatcmake` module to prevent its functions from being included twice.