### PR TITLE
Add Suppot to Format File Set Headers

### DIFF
--- a/cmake/FixFormat.cmake
+++ b/cmake/FixFormat.cmake
@@ -15,7 +15,7 @@ function(target_fix_format TARGET)
     endforeach()
   endif()
 
-  # Append header files of the target to be formatted.
+  # Append header files from include directories of the target to be formatted.
   foreach(PROP INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES)
     get_target_property(TARGET_INCLUDE_DIRS ${TARGET} ${PROP})
     if(NOT "${TARGET_INCLUDE_DIRS}" STREQUAL TARGET_INCLUDE_DIRS-NOTFOUND)
@@ -25,6 +25,12 @@ function(target_fix_format TARGET)
       endforeach()
     endif()
   endforeach()
+
+  # Append header files from file set of the target to be formatted.
+  get_target_property(TARGET_HEADER_SET ${TARGET} HEADER_SET)
+  if(NOT "${TARGET_HEADER_SET}" STREQUAL TARGET_HEADER_SET-NOTFOUND)
+    list(APPEND FILES ${TARGET_HEADER_SET})
+  endif()
 
   if(FILES)
     # Set a lock file to prevent formatting from always running.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ endfunction()
 
 add_cmake_test(
   FixFormatTest.cmake
-  "Testing source codes formatting"
+  "Testing sources formatting"
   "Testing include directories formatting"
+  "Testing file set headers formatting"
 )

--- a/test/FixFormatTest.cmake
+++ b/test/FixFormatTest.cmake
@@ -6,7 +6,7 @@ endif()
 set(TEST_COUNT 0)
 
 function(check_source_codes_format)
-  cmake_parse_arguments(ARG "" "" "SRCS" ${ARGN})
+  cmake_parse_arguments(ARG "USE_FILE_SET_HEADERS" "" "SRCS" ${ARGN})
 
   message(STATUS "Getting the original source file hashes")
   foreach(SRC ${ARG_SRCS})
@@ -23,10 +23,14 @@ function(check_source_codes_format)
   endforeach()
 
   message(STATUS "Configuring sample project")
+  if(ARG_USE_FILE_SET_HEADERS)
+    list(APPEND CONFIGURE_ARGS -D USE_FILE_SET_HEADERS=TRUE)
+  endif()
   execute_process(
     COMMAND ${CMAKE_COMMAND}
       -B ${CMAKE_CURRENT_LIST_DIR}/sample/build
       -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+      ${CONFIGURE_ARGS}
       --fresh
       ${CMAKE_CURRENT_LIST_DIR}/sample
     ERROR_VARIABLE ERR
@@ -55,7 +59,7 @@ function(check_source_codes_format)
   endforeach()
 endfunction()
 
-if("Testing source codes formatting" MATCHES ${TEST_MATCHES})
+if("Testing sources formatting" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
   check_source_codes_format(
     SRCS
@@ -67,6 +71,17 @@ endif()
 if("Testing include directories formatting" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
   check_source_codes_format(
+    SRCS
+      include/sample/fibonacci.hpp
+      include/sample/is_odd.hpp
+      include/sample.hpp
+  )
+endif()
+
+if("Testing file set headers formatting" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+  check_source_codes_format(
+    USE_FILE_SET_HEADERS
     SRCS
       include/sample/fibonacci.hpp
       include/sample/is_odd.hpp

--- a/test/sample/CMakeLists.txt
+++ b/test/sample/CMakeLists.txt
@@ -6,6 +6,19 @@ set(CMAKE_CXX_STANDARD 11)
 include(FixFormat)
 
 add_library(sample src/fibonacci.cpp src/is_odd.cpp)
-target_include_directories(sample PUBLIC include)
+
+if(USE_FILE_SET_HEADERS)
+  target_sources(
+    sample PUBLIC
+    FILE_SET HEADERS
+    BASE_DIRS include
+    FILES
+      include/sample/fibonacci.hpp
+      include/sample/is_odd.hpp
+      include/sample.hpp
+  )
+else()
+  target_include_directories(sample PUBLIC include)
+endif()
 
 target_fix_format(sample)


### PR DESCRIPTION
This pull request resolves #7 by adding support in the `target_fix_format` function to format header files which is set from the `target_sources(FILE_SET HEADERS)`. It also adds a new test case for testing that functionality.