### PR TITLE
Delay Copy Step in Testing

### DIFF
--- a/test/FixFormatTest.cmake
+++ b/test/FixFormatTest.cmake
@@ -15,7 +15,7 @@ function(check_source_codes_format)
 
   execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 1)
 
-  message(STATUS "Copying the ugly source files")
+  message(STATUS "Copying the dirty source files")
   foreach(SRC ${ARG_SRCS})
     file(
       COPY_FILE

--- a/test/FixFormatTest.cmake
+++ b/test/FixFormatTest.cmake
@@ -13,6 +13,8 @@ function(check_source_codes_format)
     file(MD5 ${CMAKE_CURRENT_LIST_DIR}/sample/${SRC} ${SRC}_HASH)
   endforeach()
 
+  execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 1)
+
   message(STATUS "Copying the ugly source files")
   foreach(SRC ${ARG_SRCS})
     file(


### PR DESCRIPTION
This pull request resolves #23 by adding a delay before the step for copying the dirty source files.