### PR TITLE
Run Test Workflow on Ubuntu and Windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,11 @@ on:
 jobs:
   test-project:
     name: Test Project
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1


### PR DESCRIPTION
This pull request resolves #25 by running the `test` workflow on the Ubuntu and Windows runners. 