### PR TITLE
Add Configure ClangFormat Formatting Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ This module primarily includes a [`target_fix_format`](./cmake/FixFormat.cmake) 
 Behind the scenes, this module utilizes [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) to format the source codes.
 To enable the formatting to be fixed before the compilation step, the module searches through all source files used by the target and creates a format target that the main target later depends on.
 
+## Requirements
+
+- CMake version 3.21 or above.
+- ClangFormat.
+
 ## Integration
 
 ### Including the Script File

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ target_include_directories(main PRIVATE include)
 target_fix_format(main)
 ```
 
+### Configuring the Formatting Style
+
+Similar to ClangFormat, you can configure the formatting style by including a `.clang-format` file.
+Refer to [this documentation](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) for more information on configuring the formatting style.
+
 ## License
 
 This project is licensed under the terms of the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@
 [![build status](https://img.shields.io/github/actions/workflow/status/threeal/FixFormat.cmake/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/FixFormat.cmake/actions/workflows/build.yaml)
 [![test status](https://img.shields.io/github/actions/workflow/status/threeal/FixFormat.cmake/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/FixFormat.cmake/actions/workflows/test.yaml)
 
-FixFormat.cmake is a [CMake](https://cmake.org/) module that provides utility functions for fixing source codes formatting during your project's build process.
-This module mainly contains a `target_fix_format` function for fixing the source codes formatting required by the target before the compilation step.
+
+**FixFormat.cmake** is a [CMake](https://cmake.org/) module that provides utility functions for fixing source code formatting during your project's build process.
+This module primarily includes a [`target_fix_format`](./cmake/FixFormat.cmake) function designed to fix the source code formatting required by the target before the compilation step.
+
+Behind the scenes, this module utilizes [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) to format the source codes.
+To enable the formatting to be fixed before the compilation step, the module searches through all source files used by the target and creates a format target that the main target later depends on.
 
 ## Integration
 


### PR DESCRIPTION
This pull request resolves #29 by modifying the `README.md` file by adding the following stuffs:
- Behind the scene of ClangFormat utilization.
- A "Requirements" section.
- A "Configuring the Formatting Style" section.