### PR TITLE
Add License Notice to Exported Files

### DIFF
--- a/cmake/FixFormat.cmake
+++ b/cmake/FixFormat.cmake
@@ -1,3 +1,6 @@
+# This code is licensed under the terms of the MIT License.
+# Copyright (c) 2023-2024 Alfi Maulana
+
 include_guard(GLOBAL)
 
 # Function to format source files of a specific target.


### PR DESCRIPTION
This pull request resolves #31 by adding a license notice on top of the `cmake/FixFormat.cmake` file.