### PR TITLE
Rename Format Target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT SUBPROJECT)
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
     FixFormatConfigVersion.cmake
-    COMPATIBILITY SameMajorVersion
+    COMPATIBILITY SameMinorVersion
   )
 
   install(

--- a/cmake/FixFormat.cmake
+++ b/cmake/FixFormat.cmake
@@ -36,7 +36,7 @@ function(target_fix_format TARGET)
   if(FILES)
     # Set a lock file to prevent formatting from always running.
     get_target_property(TARGET_BINARY_DIR ${TARGET} BINARY_DIR)
-    set(TARGET_LOCK ${TARGET_BINARY_DIR}/${TARGET}_format.lock)
+    set(TARGET_LOCK ${TARGET_BINARY_DIR}/format-${TARGET}.lock)
 
     # Add a custom target for formatting source files of the target.
     add_custom_command(
@@ -46,16 +46,16 @@ function(target_fix_format TARGET)
       DEPENDS ${FILES}
       VERBATIM
     )
-    add_custom_target(${TARGET}_format DEPENDS ${TARGET_LOCK})
+    add_custom_target(format-${TARGET} DEPENDS ${TARGET_LOCK})
 
     # Mark the target to depend on the format target.
-    add_dependencies(${TARGET} ${TARGET}_format)
+    add_dependencies(${TARGET} format-${TARGET})
 
     # Mark the format all target to depend on the format target.
     if(NOT TARGET format-all)
       add_custom_target(format-all)
     endif()
-    add_dependencies(format-all ${TARGET}_format)
+    add_dependencies(format-all format-${TARGET})
   else()
     message(WARNING "Target `${TARGET}` does not have any source files")
   endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,5 +15,6 @@ add_cmake_test(
   "Testing sources formatting"
   "Testing include directories formatting"
   "Testing file set headers formatting"
-  "Testing formatting without build"
+  "Testing formatting a target without build"
+  "Testing formatting all targets without build"
 )

--- a/test/FixFormatTest.cmake
+++ b/test/FixFormatTest.cmake
@@ -105,7 +105,20 @@ if("Testing file set headers formatting" MATCHES ${TEST_MATCHES})
   )
 endif()
 
-if("Testing formatting without build" MATCHES ${TEST_MATCHES})
+if("Testing formatting a target without build" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+  check_source_codes_format(
+    FORMAT_TARGET sample_format
+    SRCS
+      include/sample/fibonacci.hpp
+      include/sample/is_odd.hpp
+      include/sample.hpp
+      src/fibonacci.cpp
+      src/is_odd.cpp
+  )
+endif()
+
+if("Testing formatting all targets without build" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
   check_source_codes_format(
     FORMAT_TARGET format-all

--- a/test/FixFormatTest.cmake
+++ b/test/FixFormatTest.cmake
@@ -6,7 +6,7 @@ endif()
 set(TEST_COUNT 0)
 
 function(check_source_codes_format)
-  cmake_parse_arguments(ARG "USE_FILE_SET_HEADERS;WITHOUT_BUILD" "" "SRCS" ${ARGN})
+  cmake_parse_arguments(ARG "USE_FILE_SET_HEADERS" "FORMAT_TARGET" "SRCS" ${ARGN})
 
   message(STATUS "Getting the original source file hashes")
   foreach(SRC ${ARG_SRCS})
@@ -42,12 +42,12 @@ function(check_source_codes_format)
     message(FATAL_ERROR "Failed to configure sample project: ${ERR}")
   endif()
 
-  if(ARG_WITHOUT_BUILD)
+  if(ARG_FORMAT_TARGET)
     message(STATUS "Formatting sample project")
     execute_process(
       COMMAND ${CMAKE_COMMAND}
         --build ${CMAKE_CURRENT_LIST_DIR}/sample/build
-        --target format-all
+        --target ${ARG_FORMAT_TARGET}
       ERROR_VARIABLE ERR
       RESULT_VARIABLE RES
     )
@@ -108,7 +108,7 @@ endif()
 if("Testing formatting without build" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
   check_source_codes_format(
-    WITHOUT_BUILD
+    FORMAT_TARGET format-all
     SRCS
       include/sample/fibonacci.hpp
       include/sample/is_odd.hpp

--- a/test/FixFormatTest.cmake
+++ b/test/FixFormatTest.cmake
@@ -108,7 +108,7 @@ endif()
 if("Testing formatting a target without build" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
   check_source_codes_format(
-    FORMAT_TARGET sample_format
+    FORMAT_TARGET format-sample
     SRCS
       include/sample/fibonacci.hpp
       include/sample/is_odd.hpp


### PR DESCRIPTION
This pull request resolves #37 by introducing the following changes:
- Renames the generated format target to use the `format-<TARGET>` naming style.
- Modifies testing to allow testing formatting without building by calling the format target directly, instead of just the `format-all` target.
- Adjusts the version compatibility to `SameMinorVersion` because this pull request changes the format target name, which won't be compatible with the previous version with the same major version.