### PR TITLE
Restrict Formatting Only to Library and Executable Targets

### DIFF
--- a/cmake/FixFormat.cmake
+++ b/cmake/FixFormat.cmake
@@ -78,6 +78,12 @@ endfunction()
 function(add_fix_format)
   get_directory_property(TARGETS BUILDSYSTEM_TARGETS)
   foreach(TARGET ${TARGETS})
+    # Skip formatting non-library and non-executable targets.
+    get_target_property(TARGET_TYPE ${TARGET} TYPE)
+    if(NOT TARGET_TYPE MATCHES "LIBRARY$" AND NOT TARGET_TYPE EQUAL EXECUTABLE)
+      continue()
+    endif()
+
     target_fix_format(${TARGET})
   endforeach()
 endfunction()

--- a/cmake/FixFormat.cmake
+++ b/cmake/FixFormat.cmake
@@ -78,6 +78,11 @@ endfunction()
 function(add_fix_format)
   get_directory_property(TARGETS BUILDSYSTEM_TARGETS)
   foreach(TARGET ${TARGETS})
+    # Skip if the format target is already exists.
+    if(TARGET format-${TARGET})
+      return()
+    endif()
+
     # Skip formatting non-library and non-executable targets.
     get_target_property(TARGET_TYPE ${TARGET} TYPE)
     if(NOT TARGET_TYPE MATCHES "LIBRARY$" AND NOT TARGET_TYPE EQUAL EXECUTABLE)

--- a/cmake/FixFormat.cmake
+++ b/cmake/FixFormat.cmake
@@ -13,6 +13,13 @@ function(target_fix_format TARGET)
     return()
   endif()
 
+  # Skip formatting non-library and non-executable targets.
+  get_target_property(TARGET_TYPE ${TARGET} TYPE)
+  if(NOT TARGET_TYPE MATCHES "LIBRARY$" AND NOT TARGET_TYPE EQUAL EXECUTABLE)
+    message(WARNING "Cannot format `${TARGET}` target of type: ${TARGET_TYPE}")
+    return()
+  endif()
+
   find_program(CLANG_FORMAT_PROGRAM clang-format REQUIRED)
 
   # Append source files of the target to be formatted.


### PR DESCRIPTION
This pull request resolves #48 by restricting the `target_fix_format` and `add_fix_format` functions from formatting non-library and non-executable targets. It also restricts the `add_fix_format` function from formatting a same target more than once.