### PR TITLE
Fix Format Targets Argument in Testing

### DIFF
--- a/test/FixFormatTest.cmake
+++ b/test/FixFormatTest.cmake
@@ -10,7 +10,7 @@ function(check_source_codes_format)
     ARG
     "USE_GLOBAL_FORMAT;USE_FILE_SET_HEADERS;FORMAT_TWICE"
     ""
-    "SRCS;FORMAT_TARGET"
+    "SRCS;FORMAT_TARGETS"
     ${ARGN}
   )
 


### PR DESCRIPTION
This pull request resolves #63 by fixing the argument to be parsed by the `check_source_codes_format` from `FORMAT_TARGET` to `FORMAT_TARGETS`.