### PR TITLE
Specify CMake Minimum Version in Test Modules

### DIFF
--- a/test/FixFormatTest.cmake
+++ b/test/FixFormatTest.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
 function(check_source_codes_format)
   cmake_parse_arguments(
     ARG


### PR DESCRIPTION
This pull request resolves #84  by simply specifying the CMake minimum required version in the test modules.