### PR TITLE
Allow Spaces in Test Function Names

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,10 @@
 function(add_cmake_test FILE)
   foreach(NAME ${ARGN})
-    string(TOLOWER "${NAME}" TEST_COMMAND)
-    string(REPLACE " " "_" TEST_COMMAND "${TEST_COMMAND}")
     add_test(
       NAME "${NAME}"
       COMMAND "${CMAKE_COMMAND}"
         -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
-        -D TEST_COMMAND=${TEST_COMMAND}
+        -D TEST_COMMAND=${NAME}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
     )
   endforeach()

--- a/test/FixFormatTest.cmake
+++ b/test/FixFormatTest.cmake
@@ -103,7 +103,7 @@ function(check_source_codes_format)
   endforeach()
 endfunction()
 
-function(test_format_sources_files)
+function("Format sources files")
   check_source_codes_format(
     SRCS
       src/fibonacci.cpp
@@ -112,7 +112,7 @@ function(test_format_sources_files)
   )
 endfunction()
 
-function(test_format_include_directories)
+function("Format include directories")
   check_source_codes_format(
     SRCS
       include/sample/fibonacci.hpp
@@ -121,7 +121,7 @@ function(test_format_include_directories)
   )
 endfunction()
 
-function(test_format_header_files)
+function("Format header files")
   check_source_codes_format(
     USE_FILE_SET_HEADERS
     SRCS
@@ -131,30 +131,30 @@ function(test_format_header_files)
   )
 endfunction()
 
-function(test_format_all_files_globally)
+function("Format all files globally")
   check_source_codes_format(USE_GLOBAL_FORMAT)
 endfunction()
 
-function(test_format_all_files_of_some_targets_without_building)
+function("Format all files of some targets without building")
   check_source_codes_format(FORMAT_TARGETS format-sample format-main)
 endfunction()
 
-function(test_format_all_files_of_all_targets_without_building)
+function("Format all files of all targets without building")
   check_source_codes_format(FORMAT_TARGETS format-all)
 endfunction()
 
-function(test_format_all_files_twice)
+function("Format all files twice")
   check_source_codes_format(FORMAT_TWICE)
 endfunction()
 
-function(test_format_all_files_globally_twice)
+function("Format all files globally twice")
   check_source_codes_format(USE_GLOBAL_FORMAT FORMAT_TWICE)
 endfunction()
 
 if(NOT DEFINED TEST_COMMAND)
   message(FATAL_ERROR "The 'TEST_COMMAND' variable should be defined")
-elseif(NOT COMMAND test_${TEST_COMMAND})
-  message(FATAL_ERROR "Unable to find a command named 'test_${TEST_COMMAND}'")
+elseif(NOT COMMAND "${TEST_COMMAND}")
+  message(FATAL_ERROR "Unable to find a command named '${TEST_COMMAND}'")
 endif()
 
-cmake_language(CALL test_${TEST_COMMAND})
+cmake_language(CALL "${TEST_COMMAND}")

--- a/test/FixFormatTest.cmake
+++ b/test/FixFormatTest.cmake
@@ -151,10 +151,4 @@ function("Format all files globally twice")
   check_source_codes_format(USE_GLOBAL_FORMAT FORMAT_TWICE)
 endfunction()
 
-if(NOT DEFINED TEST_COMMAND)
-  message(FATAL_ERROR "The 'TEST_COMMAND' variable should be defined")
-elseif(NOT COMMAND "${TEST_COMMAND}")
-  message(FATAL_ERROR "Unable to find a command named '${TEST_COMMAND}'")
-endif()
-
 cmake_language(CALL "${TEST_COMMAND}")


### PR DESCRIPTION
This pull request resolves #86 by allowing spaces in the test function names, enabling the test function to have the same name as the test name. This change also removes unnecessary if guards before calling the test command.