### PR TITLE
Improve Function Arguments Handling 

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,11 @@
 function(add_cmake_test FILE)
-  foreach(NAME ${ARGN})
+  math(EXPR STOP "${ARGC} - 1")
+  foreach(I RANGE 1 "${STOP}")
     add_test(
-      NAME "${NAME}"
+      NAME "${ARGV${I}}"
       COMMAND "${CMAKE_COMMAND}"
         -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
-        -D TEST_COMMAND=${NAME}
+        -D "TEST_COMMAND=${ARGV${I}}"
         -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
     )
   endforeach()

--- a/test/FixFormatTest.cmake
+++ b/test/FixFormatTest.cmake
@@ -1,13 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 
 function(check_source_codes_format)
-  cmake_parse_arguments(
-    ARG
-    "USE_GLOBAL_FORMAT;USE_FILE_SET_HEADERS;FORMAT_TWICE"
-    ""
-    "SRCS;FORMAT_TARGETS"
-    ${ARGN}
-  )
+  set(OPTIONS USE_GLOBAL_FORMAT USE_FILE_SET_HEADERS FORMAT_TWICE)
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "${OPTIONS}" "" "SRCS;FORMAT_TARGETS")
 
   # Use the default source files if not specified.
   if(NOT ARG_SRCS)


### PR DESCRIPTION
This pull request resolves #90 by introducing the following changes:
- Utilizes the `ARGC` and `ARGV<INDEX>` variables in the `add_cmake_test` function.
- Utilizes the `PARSE_ARGV` version of the `cmake_parse_arguments` function, replacing the standard usage which utilized `ARGN`.