### PR TITLE
Add Option to Enable Install Targets 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,14 +8,17 @@ project(
   LANGUAGES NONE
 )
 
+option(FIX_FORMAT_ENABLE_INSTALL "Enable install targets."
+  "${PROJECT_IS_TOP_LEVEL}")
+
 include(cmake/FixFormat.cmake)
 
-if(PROJECT_IS_TOP_LEVEL)
-  if(BUILD_TESTING)
-    enable_testing()
-    add_subdirectory(test)
-  endif()
+if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(test)
+endif()
 
+if(FIX_FORMAT_ENABLE_INSTALL)
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
     FixFormatConfigVersion.cmake


### PR DESCRIPTION
This pull request resolves #100 by adding a `FIX_FORMAT_ENABLE_INSTALL` option to enable install targets in the project. By default, this option is enabled if the `PROJECT_IS_TOP_LEVEL` variable is also enabled.