### PR TITLE
Bump Assertion.cmake to Version 2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,12 +18,13 @@ if(FIX_FORMAT_ENABLE_TESTS)
   enable_testing()
 
   file(
-    DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
-      ${CMAKE_BINARY_DIR}/Assertion.cmake
-    EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
-  include(${CMAKE_BINARY_DIR}/Assertion.cmake)
+    DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v2.0.0/Assertion.cmake
+      ${CMAKE_BINARY_DIR}/cmake/Assertion.cmake
+    EXPECTED_MD5 5ebe475aee6fc5660633152f815ce9f6)
+  include(${CMAKE_BINARY_DIR}/cmake/Assertion.cmake)
 
-  assertion_add_test(test/fix_format.cmake)
+  add_cmake_script_test(test/fix_format.cmake
+    DEFINITIONS CMAKE_MODULE_PATH=${CMAKE_BINARY_DIR}/cmake)
 endif()
 
 if(FIX_FORMAT_ENABLE_INSTALL)

--- a/test/fix_format.cmake
+++ b/test/fix_format.cmake
@@ -1,3 +1,7 @@
+cmake_minimum_required(VERSION 3.21)
+
+include(Assertion)
+
 function(check_source_codes_format)
   set(OPTIONS USE_GLOBAL_FORMAT USE_FILE_SET_HEADERS FORMAT_TWICE)
   cmake_parse_arguments(PARSE_ARGV 0 ARG "${OPTIONS}" "" "SRCS;FORMAT_TARGETS")


### PR DESCRIPTION
This pull request updates the [Assertion.cmake](https://github.com/threeal/assertion-cmake/) project used by this project to version [2.0.0](https://github.com/threeal/assertion-cmake/releases/tag/v2.0.0). The change also updates the test declarations accordingly, following the changes implemented in the new version.