### PR TITLE
Add CPack Support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,10 +15,10 @@ jobs:
       - name: Configure Project
         run: cmake --preset default
 
-      - name: Install Project
-        run: cmake --install build --prefix install
+      - name: Package Project
+        run: cpack --preset default
 
       - name: Upload Project as Artifact
         uses: actions/upload-artifact@v4.4.3
         with:
-          path: install
+          path: build/FixFormat.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 !.git*
 
 build
-install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,4 +41,7 @@ if(FIX_FORMAT_ENABLE_INSTALL)
       ${CMAKE_CURRENT_BINARY_DIR}/FixFormatConfigVersion.cmake
     DESTINATION lib/cmake/FixFormat
   )
+
+  set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}")
+  include(CPack)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 6,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 21
+    "minor": 25
   },
   "configurePresets": [
     {
@@ -27,6 +27,13 @@
       "execution": {
         "noTestsAction": "error"
       }
+    }
+  ],
+  "packagePresets": [
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "generators": ["TGZ"]
     }
   ]
 }


### PR DESCRIPTION
This pull request resolves #126 by adding CPack support to the project, which includes a new `default` package preset and updates the workflow to package the project instead of installing it. It also removes the `install` directory from the Git ignore list.